### PR TITLE
Specify mixin minVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,6 @@ No easing parameters are supported. (everything was copied from easings.net)
 > GeckoLib is not guaranteed to work, but you can try! (It will work most of the time)  
 > [molang](https://docs.microsoft.com/minecraft/creator/reference/content/molangreference/) is not supported  
 
+
+## If you have questions, feel free to ask on Discord:  
+https://discord.com/invite/x22jkxRpsD

--- a/minecraft/common/src/main/resources/playerAnimator-common.mixins.json
+++ b/minecraft/common/src/main/resources/playerAnimator-common.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "dev.kosmx.playerAnim.mixin",
   "compatibilityLevel": "JAVA_16",
   "client": [

--- a/minecraft/common/src/main/resources/playerAnimator-onlyBend.mixins.json
+++ b/minecraft/common/src/main/resources/playerAnimator-onlyBend.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "dev.kosmx.playerAnim.mixin",
   "compatibilityLevel": "JAVA_16",
   "client": [


### PR DESCRIPTION
Remove warnings like 
```
[18:26:34] [main/ERROR] [mixin/]: Mixin config bendylib.mixins.json does not specify "minVersion" property
[18:26:34] [main/ERROR] [mixin/]: Mixin config playerAnimator-common.mixins.json does not specify "minVersion" property
[18:26:34] [main/ERROR] [mixin/]: Mixin config emotecraft.mixins.json does not specify "minVersion" property
```