### PR TITLE
Fix bug with capes

### DIFF
--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -20,7 +20,7 @@ public class CapeLayerMixin {
     private void render(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, AbstractClientPlayer abstractClientPlayer, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
         AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
         Vec3f pos = emote.get3DTransform("torso", TransformType.POSITION, Vec3f.ZERO);
-        poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
+        poseStack.translate(pos.getX()/16, pos.getY()/16, pos.getZ()/16);
         Vec3f rot = emote.get3DTransform("torso", TransformType.ROTATION, Vec3f.ZERO);
         poseStack.mulPose(Axis.ZP.rotation(rot.getZ()));    //roll
         poseStack.mulPose(Axis.YP.rotation(rot.getY()));    //pitch


### PR DESCRIPTION
https://www.youtube.com/watch?v=DYTqP_B0CoI
This cape being moved THAT FAR was a pretty stupid mistake on my end but it should be fine now
From what I am seeing a player's cape and torso share the same pivot point so everything should be okay but it's hard for me to make sure since if you didn't know rotations don't apply to the torso for some reason at least with GeckoLib animations