### PR TITLE
Cape bug fixes... again.

### DIFF
--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -1,5 +1,6 @@
 package dev.kosmx.playerAnim.mixin;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
@@ -17,7 +18,6 @@ import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CapeLayer.class)
@@ -53,19 +53,15 @@ public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, P
         }
     }
 
-    @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;mulPose(Lorg/joml/Quaternionf;)V"))
-    private void mulPose(PoseStack instance, Quaternionf quaternionf, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
+    @WrapWithCondition(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;mulPose(Lorg/joml/Quaternionf;)V"))
+    private boolean mulPose(PoseStack instance, Quaternionf quaternionf, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
         AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
-        if (!emote.isActive()) {
-            instance.mulPose(quaternionf);
-        }
+        return !emote.isActive();
     }
 
-    @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V"))
-    private void translate(PoseStack instance, float f, float g, float h, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
+    @WrapWithCondition(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V"))
+    private boolean translate(PoseStack instance, float f, float g, float h, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
         AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
-        if (!emote.isActive()) {
-            instance.translate(f, g, h);
-        }
+        return !emote.isActive();
     }
 }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import dev.kosmx.playerAnim.core.util.Pair;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
 import dev.kosmx.playerAnim.impl.animation.AnimationApplier;
 import net.minecraft.client.model.PlayerModel;
@@ -31,11 +32,17 @@ public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, P
         AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
         if (emote.isActive()) {
             ModelPart torso = this.getParentModel().body;
+            Pair<Float, Float> bend = emote.getBend("torso");
 
-            poseStack.rotateAround((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot, torso.zRot), torso.x/16, torso.y/16, torso.z/16);
+            poseStack.rotateAround((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot + bend.getLeft(), torso.zRot), torso.x/16, torso.y/16, torso.z/16);
 
             poseStack.translate(0.0F, 0.0F, 0.125F);
             poseStack.translate(torso.x / 16, torso.y / 16, torso.z / 16);
+            if (bend.getRight() != 0) {
+                poseStack.translate(0, 0.375F * torso.yScale, 0);
+                poseStack.mulPose(Axis.XP.rotation(bend.getRight()));
+                poseStack.translate(0, -0.375F * torso.yScale, 0);
+            }
 
             double d = Mth.lerp(h, abstractClientPlayer.xCloakO, abstractClientPlayer.xCloak)
                     - Mth.lerp(h, abstractClientPlayer.xo, abstractClientPlayer.getX());
@@ -48,8 +55,12 @@ public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, P
             s = Mth.clamp(s, -20.0F, 20.0F);
 
             poseStack.mulPose(Axis.XP.rotationDegrees(6.0F / 2.0F));
-            poseStack.mulPose(Axis.ZP.rotationDegrees(s / 2.0F));
             poseStack.mulPose(Axis.YP.rotationDegrees(180.0F - s / 2.0F));
+
+            ModelPart cape = ((PlayerModelAccessor)this.getParentModel()).getCloak();
+            cape.x = 0;
+            cape.y = 0;
+            cape.z = 0;
         }
     }
 

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -1,5 +1,6 @@
 package dev.kosmx.playerAnim.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
@@ -14,7 +15,6 @@ import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.util.Mth;
 import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -22,16 +22,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CapeLayer.class)
 public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
-    @Unique
-    private AbstractClientPlayer currentPlayer;
-
     public CapeLayerMixin(RenderLayerParent<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> renderLayerParent) {
         super(renderLayerParent);
-    }
-
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "HEAD"))
-    private void renderHead(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, AbstractClientPlayer abstractClientPlayer, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
-        currentPlayer = abstractClientPlayer;
     }
 
     @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/PlayerModel;renderCloak(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
@@ -62,16 +54,16 @@ public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, P
     }
 
     @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;mulPose(Lorg/joml/Quaternionf;)V"))
-    private void mulPose(PoseStack instance, Quaternionf quaternionf) {
-        AnimationApplier emote = ((IAnimatedPlayer) currentPlayer).playerAnimator_getAnimation();
+    private void mulPose(PoseStack instance, Quaternionf quaternionf, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
+        AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
         if (!emote.isActive()) {
             instance.mulPose(quaternionf);
         }
     }
 
     @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V"))
-    private void translate(PoseStack instance, float f, float g, float h) {
-        AnimationApplier emote = ((IAnimatedPlayer) currentPlayer).playerAnimator_getAnimation();
+    private void translate(PoseStack instance, float f, float g, float h, @Local(argsOnly = true) AbstractClientPlayer abstractClientPlayer) {
+        AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
         if (!emote.isActive()) {
             instance.translate(f, g, h);
         }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -2,28 +2,78 @@ package dev.kosmx.playerAnim.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import dev.kosmx.playerAnim.api.TransformType;
-import dev.kosmx.playerAnim.core.util.Vec3f;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
 import dev.kosmx.playerAnim.impl.animation.AnimationApplier;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.CapeLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.util.Mth;
+import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CapeLayer.class)
-public class CapeLayerMixin {
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At("HEAD"))
+public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
+    @Unique
+    private AbstractClientPlayer currentPlayer;
+
+    public CapeLayerMixin(RenderLayerParent<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> renderLayerParent) {
+        super(renderLayerParent);
+    }
+
+    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "HEAD"))
+    private void renderHead(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, AbstractClientPlayer abstractClientPlayer, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
+        currentPlayer = abstractClientPlayer;
+    }
+
+    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/PlayerModel;renderCloak(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
     private void render(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, AbstractClientPlayer abstractClientPlayer, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
         AnimationApplier emote = ((IAnimatedPlayer) abstractClientPlayer).playerAnimator_getAnimation();
-        Vec3f pos = emote.get3DTransform("torso", TransformType.POSITION, Vec3f.ZERO);
-        poseStack.translate(pos.getX()/16, pos.getY()/16, pos.getZ()/16);
-        Vec3f rot = emote.get3DTransform("torso", TransformType.ROTATION, Vec3f.ZERO);
-        poseStack.mulPose(Axis.ZP.rotation(rot.getZ()));    //roll
-        poseStack.mulPose(Axis.YP.rotation(rot.getY()));    //pitch
-        poseStack.mulPose(Axis.XP.rotation(rot.getX()));    //yaw
+        if (emote.isActive()) {
+            ModelPart torso = this.getParentModel().body;
+
+            poseStack.rotateAround((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot, torso.zRot), torso.x/16, torso.y/16, torso.z/16);
+
+            poseStack.translate(0.0F, 0.0F, 0.125F);
+            poseStack.translate(torso.x / 16, torso.y / 16, torso.z / 16);
+
+            double d = Mth.lerp(h, abstractClientPlayer.xCloakO, abstractClientPlayer.xCloak)
+                    - Mth.lerp(h, abstractClientPlayer.xo, abstractClientPlayer.getX());
+            double m = Mth.lerp(h, abstractClientPlayer.zCloakO, abstractClientPlayer.zCloak)
+                    - Mth.lerp(h, abstractClientPlayer.zo, abstractClientPlayer.getZ());
+            float n = Mth.rotLerp(h, abstractClientPlayer.yBodyRotO, abstractClientPlayer.yBodyRot);
+            double o = Mth.sin(n * (float) (Math.PI / 180.0));
+            double p = -Mth.cos(n * (float) (Math.PI / 180.0));
+            float s = (float) (d * p - m * o) * 100.0F;
+            s = Mth.clamp(s, -20.0F, 20.0F);
+
+            poseStack.mulPose(Axis.XP.rotationDegrees(6.0F / 2.0F));
+            poseStack.mulPose(Axis.ZP.rotationDegrees(s / 2.0F));
+            poseStack.mulPose(Axis.YP.rotationDegrees(180.0F - s / 2.0F));
+        }
+    }
+
+    @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;mulPose(Lorg/joml/Quaternionf;)V"))
+    private void mulPose(PoseStack instance, Quaternionf quaternionf) {
+        AnimationApplier emote = ((IAnimatedPlayer) currentPlayer).playerAnimator_getAnimation();
+        if (!emote.isActive()) {
+            instance.mulPose(quaternionf);
+        }
+    }
+
+    @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/player/AbstractClientPlayer;FFFFFF)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V"))
+    private void translate(PoseStack instance, float f, float g, float h) {
+        AnimationApplier emote = ((IAnimatedPlayer) currentPlayer).playerAnimator_getAnimation();
+        if (!emote.isActive()) {
+            instance.translate(f, g, h);
+        }
     }
 }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -34,15 +34,14 @@ public abstract class CapeLayerMixin extends RenderLayer<AbstractClientPlayer, P
             ModelPart torso = this.getParentModel().body;
             Pair<Float, Float> bend = emote.getBend("torso");
 
-            poseStack.rotateAround((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot + bend.getLeft(), torso.zRot), torso.x/16, torso.y/16, torso.z/16);
-
-            poseStack.translate(0.0F, 0.0F, 0.125F);
             poseStack.translate(torso.x / 16, torso.y / 16, torso.z / 16);
+            poseStack.mulPose((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot, torso.zRot));
             if (bend.getRight() != 0) {
                 poseStack.translate(0, 0.375F * torso.yScale, 0);
                 poseStack.mulPose(Axis.XP.rotation(bend.getRight()));
                 poseStack.translate(0, -0.375F * torso.yScale, 0);
             }
+            poseStack.translate(0.0F, 0.0F, 0.125F);
 
             double d = Mth.lerp(h, abstractClientPlayer.xCloakO, abstractClientPlayer.xCloak)
                     - Mth.lerp(h, abstractClientPlayer.xo, abstractClientPlayer.getX());

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/PlayerModelAccessor.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/PlayerModelAccessor.java
@@ -1,0 +1,12 @@
+package dev.kosmx.playerAnim.mixin;
+
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerModel.class)
+public interface PlayerModelAccessor {
+    @Accessor
+    ModelPart getCloak();
+}

--- a/minecraft/common/src/main/resources/playerAnimator-common.mixins.json
+++ b/minecraft/common/src/main/resources/playerAnimator-common.mixins.json
@@ -22,6 +22,7 @@
     "firstPerson.LivingEntityRendererMixin"
   ],
   "mixins": [
+    "PlayerModelAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Capes should look a lot better now during animations.
Elytra are visually connected to the arms of the player rather than the torso so I decided not to use the same fix on that as well.
I feel like being able to have an elytra bone and a cape bone in order to animate them would be pretty dope, but for now the current fix is good enough for me and probably for most people.

Also some cosmetics mods (Specifically [this one](https://www.curseforge.com/minecraft/mc-mods/minecraftcapes-mod)) will break this fix regardless of the mixin priority
The specified mod isn't open source so I guess it isn't our problem