### PR TITLE
Fixes

### DIFF
--- a/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/AnimationFormat.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/AnimationFormat.java
@@ -1,5 +1,8 @@
 package dev.kosmx.playerAnim.core.data;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Where is the emote from
  */
@@ -12,8 +15,39 @@ public enum AnimationFormat {
     SERVER(null),
     UNKNOWN(null);
 
-    private final String extension;
+    private static final Map<String, AnimationFormat> FORMATS;
 
+    static {
+        AnimationFormat[] formatsValues = values();
+
+        FORMATS = new HashMap<>(formatsValues.length);
+
+        for (AnimationFormat format : formatsValues) {
+            if (format.extension != null)
+                FORMATS.putIfAbsent(format.extension, format);
+        }
+    }
+
+    public static AnimationFormat byFileName(String fileName) {
+        if (fileName == null || fileName.isEmpty())
+            return AnimationFormat.UNKNOWN;
+
+        int i = fileName.lastIndexOf('.');
+        if (i > 0) {
+            fileName = fileName.substring(i + 1);
+        }
+
+        return byExtension(fileName);
+    }
+
+    public static AnimationFormat byExtension(String extension) {
+        if (extension == null || extension.isEmpty())
+            return AnimationFormat.UNKNOWN;
+
+        return FORMATS.getOrDefault(extension.toLowerCase(), AnimationFormat.UNKNOWN);
+    }
+
+    private final String extension;
 
     AnimationFormat(String extension) {
         this.extension = extension;

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/AnimationJson.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/AnimationJson.java
@@ -51,7 +51,7 @@ public class AnimationJson implements JsonDeserializer<List<KeyframeAnimation>>,
         JsonObject node = json.getAsJsonObject();
 
         if(!node.has("emote")){
-            throw new JsonParseException("not an emotecraft animation");
+            return GeckoLibSerializer.deserialize(node); // TODO remove
         }
 
         int version = 1;

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/AnimationSerializing.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/AnimationSerializing.java
@@ -26,11 +26,7 @@ public class AnimationSerializing {
      */
     @Deprecated(forRemoval = true)
     public static List<KeyframeAnimation> deserializeAnimation(Reader stream) {
-        try {
-            return AnimationJson.GSON.fromJson(stream, AnimationJson.getListedTypeToken());
-        } catch (Exception e) {
-            return GeckoLibSerializer.GSON.fromJson(stream, GeckoLibSerializer.getListedTypeToken());
-        }
+        return AnimationJson.GSON.fromJson(stream, AnimationJson.getListedTypeToken());
     }
 
     /**


### PR DESCRIPTION
> Please stop removing methods from AnimationFormat, even though it is an deprecated class, there are no alternatives to it, and these are very handy methods that I use everywhere and now in emotecraft as well
> And gecko fix is needed because inputstream which is used there can be read once, respectively gecko animation will always be empty