### PR TITLE
Elytra and cape animation support.

### DIFF
--- a/coreLib/src/main/java/dev/kosmx/playerAnim/api/PartKey.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/api/PartKey.java
@@ -40,6 +40,7 @@ public class PartKey {
     public static final @NotNull PartKey RIGHT_ITEM = keyForId("rightItem");
     public static final @NotNull PartKey LEFT_ITEM = keyForId("leftItem");
     public static final @NotNull PartKey CAPE = keyForId("cape");
+    public static final @NotNull PartKey ELYTRA = keyForId("elytra");
 
 
     /**

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/core/util/Vec3f.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/core/util/Vec3f.java
@@ -6,6 +6,7 @@ import javax.annotation.concurrent.Immutable;
 public class Vec3f extends Vector3<Float> {
 
     public static final Vec3f ZERO = new Vec3f(0f, 0f, 0f);
+    public static final Vec3f ONE = new Vec3f(1f, 1f, 1f);
 
     public Vec3f(float x, float y, float z) {
         super(x, y, z);

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/CapeLayerMixin.java
@@ -5,7 +5,9 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import dev.kosmx.playerAnim.api.PartKey;
+import dev.kosmx.playerAnim.api.TransformType;
 import dev.kosmx.playerAnim.core.util.Pair;
+import dev.kosmx.playerAnim.core.util.Vec3f;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
 import dev.kosmx.playerAnim.impl.IPlayerAnimationState;
 import dev.kosmx.playerAnim.impl.animation.AnimationApplier;
@@ -24,6 +26,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Objects;
+
 @Mixin(CapeLayer.class)
 public abstract class CapeLayerMixin extends RenderLayer<PlayerRenderState, PlayerModel> {
 
@@ -37,6 +41,8 @@ public abstract class CapeLayerMixin extends RenderLayer<PlayerRenderState, Play
         if (emote.isActive()) {
             ModelPart torso = this.getParentModel().body;
             Pair<Float, Float> torsoBend = emote.getBend(PartKey.TORSO);
+            Pair<Float, Float> bodyBend = emote.getBend(PartKey.BODY);
+            bodyBend = new Pair<>(torsoBend.getLeft() + bodyBend.getLeft(), torsoBend.getRight() + bodyBend.getRight());
 
             poseStack.translate(torso.x / 16, torso.y / 16, torso.z / 16);
             poseStack.mulPose((new Quaternionf()).rotateXYZ(torso.xRot, torso.yRot, torso.zRot));
@@ -45,12 +51,27 @@ public abstract class CapeLayerMixin extends RenderLayer<PlayerRenderState, Play
             poseStack.mulPose(Axis.YP.rotationDegrees(180));
 
             ModelPart cape = ((PlayerModelAccessor)this.getParentModel()).getCloak();
-            cape.x = 0;
-            cape.y = 0;
-            cape.z = 0;
-            cape.xRot = 0;
-            cape.yRot = 0;
-            cape.zRot = 0;
+            Vec3f transform = emote.get3DTransform(PartKey.CAPE, TransformType.POSITION, Vec3f.ZERO);
+            Vec3f rotation = emote.get3DTransform(PartKey.CAPE, TransformType.ROTATION, Vec3f.ZERO);
+            Vec3f scale = emote.get3DTransform(PartKey.CAPE, TransformType.SCALE, Vec3f.ONE);
+            Pair<Float, Float> bend = emote.getBend(PartKey.CAPE);
+            if (Objects.equals(bend.getRight(), bend.getLeft()) && bend.getLeft() == 0)
+                bend = bodyBend;
+
+            cape.x = transform.getX();
+            cape.y = transform.getY();
+            cape.z = transform.getZ();
+            cape.xRot = rotation.getX();
+            cape.yRot = rotation.getY();
+            cape.zRot = rotation.getZ();
+            cape.xScale = scale.getX();
+            cape.yScale = scale.getY();
+            cape.zScale = scale.getZ();
+
+            IBendHelper.INSTANCE.bend(cape, bend);
+        }
+        else {
+            IBendHelper.INSTANCE.bend(((PlayerModelAccessor)this.getParentModel()).getCloak(), null);
         }
     }
 

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ElytraLayerMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ElytraLayerMixin.java
@@ -32,8 +32,14 @@ public abstract class ElytraLayerMixin<S extends HumanoidRenderState, M extends 
             if (emote.isActive()) {
                 Vec3f translation = emote.get3DTransform(PartKey.TORSO, TransformType.POSITION, Vec3f.ZERO);
                 Vec3f rotation = emote.get3DTransform(PartKey.TORSO, TransformType.ROTATION, Vec3f.ZERO);
+                translation = emote.get3DTransform(PartKey.CAPE, TransformType.POSITION, translation);
+                rotation = emote.get3DTransform(PartKey.CAPE, TransformType.ROTATION, rotation);
+                translation = emote.get3DTransform(PartKey.ELYTRA, TransformType.POSITION, translation);
+                rotation = emote.get3DTransform(PartKey.ELYTRA, TransformType.ROTATION, rotation);
                 poseStack.translate(translation.getX() / 16, translation.getY() / 16, translation.getZ() / 16);
                 poseStack.mulPose((new Quaternionf()).rotateXYZ(rotation.getX(), rotation.getY(), rotation.getZ()));
+                Vec3f scale = emote.get3DTransform(PartKey.ELYTRA, TransformType.SCALE, Vec3f.ONE);
+                poseStack.scale(scale.getX(), scale.getY(), scale.getZ());
                 IBendHelper.rotateMatrixStack(poseStack, emote.getBend(PartKey.TORSO));
             }
         }


### PR DESCRIPTION
Not tested, I mean, the port isn't even done yet.
I also saw that the cape bug fixes didn't make it to this version so here they are.
Related Emotecraft PR: https://github.com/KosmX/emotes/pull/512
I will back port this to 1.21 and test it when I have the energy.