### PR TITLE
feat: Added rendering of armor when using the custom first person 

### DIFF
--- a/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonConfiguration.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonConfiguration.java
@@ -15,4 +15,11 @@ public class FirstPersonConfiguration {
     boolean showRightItem = true;
     boolean showLeftItem = true;
     boolean showArmor = false;
+
+    public FirstPersonConfiguration(boolean showRightArm, boolean showLeftArm, boolean showRightItem, boolean showLeftItem) {
+        this.showRightArm = showRightArm;
+        this.showLeftArm = showLeftArm;
+        this.showRightItem = showRightItem;
+        this.showLeftItem = showLeftItem;
+    }
 }

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonConfiguration.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonConfiguration.java
@@ -14,4 +14,5 @@ public class FirstPersonConfiguration {
     boolean showLeftArm = false;
     boolean showRightItem = true;
     boolean showLeftItem = true;
+    boolean showArmor = false;
 }

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonMode.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonMode.java
@@ -15,14 +15,10 @@ public enum FirstPersonMode {
     VANILLA(true),
 
     /**
-     * Use the 3rd person player model (only arms/items) to render accurate first-person perspective
+     * Use the 3rd person player model (only arms/items/shoulder armor) to render accurate first-person perspective.
+     * Note that armor rendering is disabled in the default FirstPersonConfiguration. {@link FirstPersonConfiguration#showShoulder}
      */
     THIRD_PERSON_MODEL(true),
-
-    /**
-     * Use the 3rd person player model (only arms/items/shoulder armor) to render accurate first-person perspective
-     */
-    THIRD_PERSON_MODEL_SP(true),
 
     /**
      * First person animation is DISABLED, vanilla idle will be active.
@@ -37,6 +33,7 @@ public enum FirstPersonMode {
     FirstPersonMode(boolean enabled) {
         this.enabled = enabled;
     }
+
 
 
     private static final ThreadLocal<Boolean> firstPersonPass = ThreadLocal.withInitial(() -> false);

--- a/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonMode.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/api/firstPerson/FirstPersonMode.java
@@ -20,11 +20,16 @@ public enum FirstPersonMode {
     THIRD_PERSON_MODEL(true),
 
     /**
+     * Use the 3rd person player model (only arms/items/shoulder armor) to render accurate first-person perspective
+     */
+    THIRD_PERSON_MODEL_SP(true),
+
+    /**
      * First person animation is DISABLED, vanilla idle will be active.
      */
     DISABLED(false),
 
-;
+    ;
     @Getter
     private final boolean enabled;
 
@@ -32,7 +37,6 @@ public enum FirstPersonMode {
     FirstPersonMode(boolean enabled) {
         this.enabled = enabled;
     }
-
 
 
     private static final ThreadLocal<Boolean> firstPersonPass = ThreadLocal.withInitial(() -> false);

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
@@ -17,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static net.minecraft.world.entity.EquipmentSlot.CHEST;
+
 @Mixin(HumanoidArmorLayer.class)
 public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> extends RenderLayer<T, M> {
 
@@ -38,25 +40,14 @@ public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extend
         AnimationApplier emote = ((IAnimatedPlayer) Minecraft.getInstance().player).playerAnimator_getAnimation();
         if (emote.isActive() && emote.getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP && FirstPersonMode.isFirstPersonPass()) {
             humanoidModel.setAllVisible(false);
-
-            switch (equipmentSlot) {
-                case CHEST:
-                    if (emote.getFirstPersonConfiguration().isShowRightArm()) {
-                        humanoidModel.rightArm.visible = true;
-                    }
-                    if (emote.getFirstPersonConfiguration().isShowLeftArm()) {
-                        humanoidModel.leftArm.visible = true;
-                    }
-                    humanoidModel.body.visible = false;
-                    break;
-                case HEAD:
-                    humanoidModel.head.visible = true;
-                    humanoidModel.hat.visible = true;
-                    break;
-                case LEGS, FEET:
-                    humanoidModel.rightLeg.visible = true;
-                    humanoidModel.leftLeg.visible = true;
-                    break;
+            if (equipmentSlot == CHEST){
+                if (emote.getFirstPersonConfiguration().isShowRightArm()) {
+                    humanoidModel.rightArm.visible = true;
+                }
+                if (emote.getFirstPersonConfiguration().isShowLeftArm()) {
+                    humanoidModel.leftArm.visible = true;
+                }
+                humanoidModel.body.visible = false;
             }
             ci.cancel();
         }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
@@ -1,10 +1,16 @@
 package dev.kosmx.playerAnim.mixin;
 
+import dev.kosmx.playerAnim.api.firstPerson.FirstPersonMode;
+import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
 import dev.kosmx.playerAnim.impl.IUpperPartHelper;
+import dev.kosmx.playerAnim.impl.animation.AnimationApplier;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,10 +18,47 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HumanoidArmorLayer.class)
-public class ArmorFeatureRendererMixin<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> {
+public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> extends RenderLayer<T, M> {
+
+    protected ArmorFeatureRendererMixin(RenderLayerParent<T, M> renderLayerParent) {
+        super(renderLayerParent);
+    }
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void initInject(RenderLayerParent<T, M> context, A leggingsModel, A bodyModel, ModelManager modelManager, CallbackInfo ci){
         ((IUpperPartHelper)this).setUpperPart(false);
+    }
+
+    @Inject(
+            method = "setPartVisibility",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void modifyArmorVisibility(A humanoidModel, EquipmentSlot equipmentSlot, CallbackInfo ci) {
+        AnimationApplier emote = ((IAnimatedPlayer) Minecraft.getInstance().player).playerAnimator_getAnimation();
+        if (emote.isActive() && emote.getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP && FirstPersonMode.isFirstPersonPass()) {
+            humanoidModel.setAllVisible(false);
+
+            switch (equipmentSlot) {
+                case CHEST:
+                    if (emote.getFirstPersonConfiguration().isShowRightArm()) {
+                        humanoidModel.rightArm.visible = true;
+                    }
+                    if (emote.getFirstPersonConfiguration().isShowLeftArm()) {
+                        humanoidModel.leftArm.visible = true;
+                    }
+                    humanoidModel.body.visible = false;
+                    break;
+                case HEAD:
+                    humanoidModel.head.visible = true;
+                    humanoidModel.hat.visible = true;
+                    break;
+                case LEGS, FEET:
+                    humanoidModel.rightLeg.visible = true;
+                    humanoidModel.leftLeg.visible = true;
+                    break;
+            }
+            ci.cancel();
+        }
     }
 }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
@@ -38,7 +38,7 @@ public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extend
     )
     private void modifyArmorVisibility(A humanoidModel, EquipmentSlot equipmentSlot, CallbackInfo ci) {
         AnimationApplier emote = ((IAnimatedPlayer) Minecraft.getInstance().player).playerAnimator_getAnimation();
-        if (emote.isActive() && emote.getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP && FirstPersonMode.isFirstPersonPass()) {
+        if (emote.isActive() && emote.getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL && emote.getFirstPersonConfiguration().isShowArmor() && FirstPersonMode.isFirstPersonPass()) {
             humanoidModel.setAllVisible(false);
             if (equipmentSlot == CHEST) {
                 humanoidModel.rightArm.visible = emote.getFirstPersonConfiguration().isShowRightArm();

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/ArmorFeatureRendererMixin.java
@@ -27,8 +27,8 @@ public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extend
     }
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void initInject(RenderLayerParent<T, M> context, A leggingsModel, A bodyModel, ModelManager modelManager, CallbackInfo ci){
-        ((IUpperPartHelper)this).setUpperPart(false);
+    private void initInject(RenderLayerParent<T, M> context, A leggingsModel, A bodyModel, ModelManager modelManager, CallbackInfo ci) {
+        ((IUpperPartHelper) this).setUpperPart(false);
     }
 
     @Inject(
@@ -40,13 +40,9 @@ public abstract class ArmorFeatureRendererMixin<T extends LivingEntity, M extend
         AnimationApplier emote = ((IAnimatedPlayer) Minecraft.getInstance().player).playerAnimator_getAnimation();
         if (emote.isActive() && emote.getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP && FirstPersonMode.isFirstPersonPass()) {
             humanoidModel.setAllVisible(false);
-            if (equipmentSlot == CHEST){
-                if (emote.getFirstPersonConfiguration().isShowRightArm()) {
-                    humanoidModel.rightArm.visible = true;
-                }
-                if (emote.getFirstPersonConfiguration().isShowLeftArm()) {
-                    humanoidModel.leftArm.visible = true;
-                }
+            if (equipmentSlot == CHEST) {
+                humanoidModel.rightArm.visible = emote.getFirstPersonConfiguration().isShowRightArm();
+                humanoidModel.leftArm.visible = emote.getFirstPersonConfiguration().isShowLeftArm();
                 humanoidModel.body.visible = false;
             }
             ci.cancel();

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ItemInHandRendererMixin {
     @Inject(method = "renderHandsWithItems", at = @At("HEAD"), cancellable = true)
     private void disableDefaultItemIfNeeded(float f, PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, LocalPlayer localPlayer, int i, CallbackInfo ci) {
-        if (localPlayer instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL || player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP)) {
+        if (localPlayer instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL)) {
                 ci.cancel();
             }
 

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
@@ -19,9 +19,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ItemInHandRendererMixin {
     @Inject(method = "renderHandsWithItems", at = @At("HEAD"), cancellable = true)
     private void disableDefaultItemIfNeeded(float f, PoseStack poseStack, MultiBufferSource.BufferSource bufferSource, LocalPlayer localPlayer, int i, CallbackInfo ci) {
-        if (localPlayer instanceof IAnimatedPlayer player && player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL) {
-            ci.cancel();
-        }
+        if (localPlayer instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL || player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP)) {
+                ci.cancel();
+            }
+
     }
 
     /* AW needed, I may do it later

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LevelRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LevelRendererMixin.java
@@ -31,16 +31,16 @@ public class LevelRendererMixin {
     private void fakeThirdPersonMode(DeltaTracker deltaTracker, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
         // mods may need to redirect that method, I want to avoid compatibility issues as long as possible
         defaultCameraState = camera.isDetached();
-        if (camera.getEntity() instanceof IAnimatedPlayer player && player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL) {
-            FirstPersonMode.setFirstPersonPass(!camera.isDetached() && (!(camera.getEntity() instanceof LivingEntity) || !((LivingEntity)camera.getEntity()).isSleeping())); // this will cause a lot of pain
-            ((CameraAccessor)camera).setDetached(true);
+        if (camera.getEntity() instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL || player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP)) {
+            FirstPersonMode.setFirstPersonPass(!camera.isDetached() && (!(camera.getEntity() instanceof LivingEntity) || !((LivingEntity) camera.getEntity()).isSleeping())); // this will cause a lot of pain
+            ((CameraAccessor) camera).setDetached(true);
         }
     }
+
     @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;isDetached()Z", shift = At.Shift.AFTER))
     private void resetThirdPerson(DeltaTracker deltaTracker, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
-        ((CameraAccessor)camera).setDetached(defaultCameraState);
+        ((CameraAccessor) camera).setDetached(defaultCameraState);
     }
-
 
 
     @Inject(method = "renderEntity", at = @At("TAIL"))

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LevelRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LevelRendererMixin.java
@@ -31,7 +31,7 @@ public class LevelRendererMixin {
     private void fakeThirdPersonMode(DeltaTracker deltaTracker, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
         // mods may need to redirect that method, I want to avoid compatibility issues as long as possible
         defaultCameraState = camera.isDetached();
-        if (camera.getEntity() instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL || player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL_SP)) {
+        if (camera.getEntity() instanceof IAnimatedPlayer player && (player.playerAnimator_getAnimation().getFirstPersonMode() == FirstPersonMode.THIRD_PERSON_MODEL)) {
             FirstPersonMode.setFirstPersonPass(!camera.isDetached() && (!(camera.getEntity() instanceof LivingEntity) || !((LivingEntity) camera.getEntity()).isSleeping())); // this will cause a lot of pain
             ((CameraAccessor) camera).setDetached(true);
         }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LivingEntityRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/LivingEntityRendererMixin.java
@@ -5,6 +5,7 @@ import dev.kosmx.playerAnim.api.firstPerson.FirstPersonMode;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.client.renderer.entity.layers.PlayerItemInHandLayer;
 import net.minecraft.world.entity.LivingEntity;
 import org.objectweb.asm.Opcodes;
@@ -25,7 +26,7 @@ public class LivingEntityRendererMixin {
     at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/entity/LivingEntityRenderer;layers:Ljava/util/List;", opcode = Opcodes.GETFIELD))
     private List<Object> filterLayers(LivingEntityRenderer instance, LivingEntity entity, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i) {
         if (entity instanceof LocalPlayer && FirstPersonMode.isFirstPersonPass()) {
-            return layers.stream().filter(layer -> layer instanceof PlayerItemInHandLayer).toList();
+            return layers.stream().filter(layer -> layer instanceof PlayerItemInHandLayer || layer instanceof HumanoidArmorLayer<?,?,?>).toList();
         } else return layers;
     }
 }


### PR DESCRIPTION
A new FirstPersonMode has been added which allows the rendering of armors when using the first person custom

I have preferred to do it this way and not add each shoulder separately to FirstPersonConfiguration because I doubt that anyone would be interested in handling the rendering of the shoulder pads separately, this way it will only be visible according to the arms if both are visible their respective armor parts will be shown instead when only one is visible only that one will show its armor.