### PR TITLE
Fix Figura Item Pivot Compatibility

### DIFF
--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/HeldItemMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/HeldItemMixin.java
@@ -1,14 +1,12 @@
 package dev.kosmx.playerAnim.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Axis;
 import dev.kosmx.playerAnim.api.TransformType;
 import dev.kosmx.playerAnim.core.impl.AnimationProcessor;
 import dev.kosmx.playerAnim.core.util.Pair;
 import dev.kosmx.playerAnim.core.util.Vec3f;
 import dev.kosmx.playerAnim.impl.Helper;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
-import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.HumanoidArm;
@@ -44,28 +42,6 @@ public class HeldItemMixin {
                 matrices.mulPose(new Quaternionf().rotateAxis(bend, axis));
                 matrices.translate(0, - offset, 0);
 
-            }
-        }
-    }
-
-    @Inject(method = "renderArmWithItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ItemInHandRenderer;renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemDisplayContext;ZLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V"))
-    private void changeItemLocation(LivingEntity livingEntity, ItemStack itemStack, ItemDisplayContext itemDisplayContext, HumanoidArm arm, PoseStack matrices, MultiBufferSource multiBufferSource, int i, CallbackInfo ci) {
-        if(livingEntity instanceof IAnimatedPlayer player) {
-            if (player.playerAnimator_getAnimation().isActive()) {
-                AnimationProcessor anim = player.playerAnimator_getAnimation();
-
-                Vec3f scale = anim.get3DTransform(arm == HumanoidArm.LEFT ? "leftItem" : "rightItem", TransformType.SCALE,
-                        new Vec3f(ModelPart.DEFAULT_SCALE, ModelPart.DEFAULT_SCALE, ModelPart.DEFAULT_SCALE)
-                );
-                Vec3f rot = anim.get3DTransform(arm == HumanoidArm.LEFT ? "leftItem" : "rightItem", TransformType.ROTATION, Vec3f.ZERO);
-                Vec3f pos = anim.get3DTransform(arm == HumanoidArm.LEFT ? "leftItem" : "rightItem", TransformType.POSITION, Vec3f.ZERO).scale(1/16f);
-
-                matrices.scale(scale.getX(), scale.getY(), scale.getZ());
-                matrices.translate(pos.getX(), pos.getY(), pos.getZ());
-
-                matrices.mulPose(Axis.ZP.rotation(rot.getZ()));    //roll
-                matrices.mulPose(Axis.YP.rotation(rot.getY()));    //pitch
-                matrices.mulPose(Axis.XP.rotation(rot.getX()));    //yaw
             }
         }
     }

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/mixin/firstPerson/ItemInHandRendererMixin.java
@@ -1,9 +1,14 @@
 package dev.kosmx.playerAnim.mixin.firstPerson;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import dev.kosmx.playerAnim.api.TransformType;
 import dev.kosmx.playerAnim.api.firstPerson.FirstPersonMode;
+import dev.kosmx.playerAnim.core.impl.AnimationProcessor;
+import dev.kosmx.playerAnim.core.util.Vec3f;
 import dev.kosmx.playerAnim.impl.IAnimatedPlayer;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.ItemInHandRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -46,6 +51,37 @@ public class ItemInHandRendererMixin {
                 if (!config.isShowLeftItem()) {
                     ci.cancel();
                 }
+            }
+        }
+    }
+
+    @Inject(method = "renderItem", at = @At("HEAD"))
+    void changeItemLocation(
+            LivingEntity livingEntity,
+            ItemStack itemStack,
+            ItemDisplayContext itemDisplayContext,
+            boolean bl,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource,
+            int i,
+            CallbackInfo ci
+    ) {
+        if(livingEntity instanceof IAnimatedPlayer player) {
+            if (player.playerAnimator_getAnimation().isActive()) {
+                AnimationProcessor anim = player.playerAnimator_getAnimation();
+
+                Vec3f scale = anim.get3DTransform(bl ? "leftItem" : "rightItem", TransformType.SCALE,
+                        new Vec3f(ModelPart.DEFAULT_SCALE, ModelPart.DEFAULT_SCALE, ModelPart.DEFAULT_SCALE)
+                );
+                Vec3f rot = anim.get3DTransform(bl ? "leftItem" : "rightItem", TransformType.ROTATION, Vec3f.ZERO);
+                Vec3f pos = anim.get3DTransform(bl ? "leftItem" : "rightItem", TransformType.POSITION, Vec3f.ZERO).scale(1/16f);
+
+                poseStack.scale(scale.getX(), scale.getY(), scale.getZ());
+                poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
+
+                poseStack.mulPose(Axis.ZP.rotation(rot.getZ()));    //roll
+                poseStack.mulPose(Axis.YP.rotation(rot.getY()));    //pitch
+                poseStack.mulPose(Axis.XP.rotation(rot.getX()));    //yaw
             }
         }
     }


### PR DESCRIPTION
Moved changeItemLocation from HeldItemMixin to ItemInHandRendererMixin so that the item pivot is animated even when Figura cancels renderArmWithItem.

https://github.com/user-attachments/assets/f4f5e65e-31e1-4615-9e9d-5f8384a4de61

