### PR TITLE
Fix crashes and log spam with PAL present

### DIFF
--- a/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/GeckoLibSerializer.java
+++ b/coreLib/src/main/java/dev/kosmx/playerAnim/core/data/gson/GeckoLibSerializer.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,9 +56,8 @@ public class GeckoLibSerializer implements JsonDeserializer<List<KeyframeAnimati
     public static List<KeyframeAnimation> deserialize(JsonObject node){
         try {
             return readAnimations(node.get("animations").getAsJsonObject());
-        } catch(NumberFormatException e) {
-            throw new JsonParseException(e);
-        }
+        } catch(NumberFormatException ignore ) {} //Probably due to encountering PAL MoLang
+        return Collections.emptyList();
     }
 
     private static List<KeyframeAnimation> readAnimations(JsonObject jsonEmotes){
@@ -89,8 +89,6 @@ public class GeckoLibSerializer implements JsonDeserializer<List<KeyframeAnimati
                 builder.returnTick = 0;
 
                 keyframeSerializer(builder, node.get("bones").getAsJsonObject());
-            } else {
-                throw new JsonParseException("Could not recognise GeckoLib animation: " + name);
             }
 
             emotes.add(builder.build());

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ minecraft_version=1.21.1
 
 archives_base_name=player-animation-lib
 #Major: API break, Minor: non-breaking but significant, Patch: minor bugfix/change + MC implementation fix
-mod_version=2.0.1
+mod_version=2.0.2
 maven_group=dev.kosmx.player-anim
 
 

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/minecraftApi/PlayerAnimationRegistry.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/minecraftApi/PlayerAnimationRegistry.java
@@ -113,7 +113,11 @@ public final class PlayerAnimationRegistry {
                 }
             });
             for(var animation: a) {
-                animations.put(ResourceLocation.fromNamespaceAndPath(resource.getKey().getNamespace(), serializeTextToString(animation.getName())), animation);
+                try {
+                    animations.put(ResourceLocation.fromNamespaceAndPath(resource.getKey().getNamespace(), serializeTextToString(animation.getName())), animation);
+                } catch (Throwable e) {
+                    logger.debug("Failed to load animation with name space {} and name {}. Either a PAL animation or has an invalid name.", resource.getKey().getNamespace(), animation.getName());
+                }
             }
         }
         for (var resource: manager.listResources("player_animation", ignore -> true).entrySet()) {

--- a/minecraft/common/src/main/java/dev/kosmx/playerAnim/minecraftApi/codec/AnimationCodecs.java
+++ b/minecraft/common/src/main/java/dev/kosmx/playerAnim/minecraftApi/codec/AnimationCodecs.java
@@ -73,8 +73,8 @@ public class AnimationCodecs {
 
         for (AnimationCodec<?> deserializer: extension == null ? AnimationCodecs.INSTANCE.getAllCodecs() : AnimationCodecs.INSTANCE.getCodec(extension)) {
             try (var reader = inputStreamSupplier.get()) {
+                if (reader == null) break;
                 final var result = deserializer.decode(new BufferedInputStream(reader));
-                if (result.isEmpty()) throw new RuntimeException("Decoder is not obeying API");
 
                 animations.addAll(result);
                 break;


### PR DESCRIPTION
So unfortunately the animation loading system for player animator wasn't written to be very failsafe, so a lot of crashes and log spam occurs when it encounters animations from PAL it was never designed to load
I had to backport PAL to 1.21.1 because I needed the extra features, and now others have started using it too
I hope the two libraries can be made compatible via this PR (Though I might have to make more if I missed something)
Please merge and publish this asap I have tested it and it appears to work just fine